### PR TITLE
Ability to change the visibility of all pieces

### DIFF
--- a/demo/src/com/commonsware/cwac/merge/demo/MergeAdapterDemo.java
+++ b/demo/src/com/commonsware/cwac/merge/demo/MergeAdapterDemo.java
@@ -38,7 +38,10 @@ public class MergeAdapterDemo extends ListActivity {
           "augue", "purus" };
   private MergeAdapter adapter=null;
   private ArrayAdapter<String> arrayAdapter=null;
-
+  
+  private int firstNo = -1;
+  private int labelPieceNo = -1;
+  
   @Override
   public void onCreate(Bundle icicle) {
     super.onCreate(icicle);
@@ -46,10 +49,12 @@ public class MergeAdapterDemo extends ListActivity {
 
     adapter=new MergeAdapter();
     arrayAdapter=buildFirstList();
-    adapter.addAdapter(arrayAdapter);
-    adapter.addView(buildButton(), true);
+    firstNo = adapter.addAdapter(arrayAdapter);
+    adapter.addView(buildToggleFirstAdapter(), true, true);
+    adapter.addView(buildCapitalizeButton(), true, true);
     adapter.addAdapter(buildSecondList());
-    adapter.addView(buildLabel());
+    labelPieceNo=adapter.addView(buildLabel());
+    adapter.addView(buildToggleLabelButton(), true, true);
     adapter.addAdapter(buildSecondList());
 
     setListAdapter(adapter);
@@ -77,7 +82,7 @@ public class MergeAdapterDemo extends ListActivity {
                                                                 .asList(items))));
   }
 
-  private View buildButton() {
+  private View buildCapitalizeButton() {
     Button result=new Button(this);
 
     result.setText("Add Capitalized Words");
@@ -91,6 +96,36 @@ public class MergeAdapterDemo extends ListActivity {
 
     return(result);
   }
+  
+	private View buildToggleLabelButton() {
+		Button result = new Button(this);
+
+		result.setText("Toggle Label");
+		result.setOnClickListener(new View.OnClickListener() {
+			public void onClick(View v) {
+				if(labelPieceNo!=-1) {
+				  adapter.setVisible(labelPieceNo, !adapter.isVisible(labelPieceNo));
+				}
+			}
+		});
+
+		return (result);
+	}
+	
+	 private View buildToggleFirstAdapter() {
+	    Button result = new Button(this);
+
+	    result.setText("Toggle First");
+	    result.setOnClickListener(new View.OnClickListener() {
+	      public void onClick(View v) {
+	        if(firstNo!=-1) {
+	          adapter.setVisible(firstNo, !adapter.isVisible(firstNo));
+	        }
+	      }
+	    });
+
+	    return (result);
+	  }
 
   private View buildLabel() {
     TextView result=new TextView(this);

--- a/src/com/commonsware/cwac/merge/MergeSpinnerAdapter.java
+++ b/src/com/commonsware/cwac/merge/MergeSpinnerAdapter.java
@@ -37,8 +37,12 @@ public class MergeSpinnerAdapter extends MergeAdapter {
    */
   public View getDropDownView(int position, View convertView,
                               ViewGroup parent) {
-    for (ListAdapter piece : pieces) {
-      int size=piece.getCount();
+    for (ToggleableListAdapter piece : pieces) {
+      if(!piece.visible) {
+        continue;
+      }
+      
+      int size=piece.adapter.getCount();
 
       if (position<size) {
         return(((SpinnerAdapter)piece).getDropDownView(position,
@@ -59,7 +63,7 @@ public class MergeSpinnerAdapter extends MergeAdapter {
    * @param view
    *          Single view to add
    */
-  public void addView(View view) {
+  public int addView(View view) {
     throw new RuntimeException("Not supported with MergeSpinnerAdapter");
   }
 
@@ -72,7 +76,7 @@ public class MergeSpinnerAdapter extends MergeAdapter {
    * @param enabled
    *          false if views are disabled, true if enabled
    */
-  public void addView(View view, boolean enabled) {
+  public int addView(View view, boolean enabled, boolean visible) {
     throw new RuntimeException("Not supported with MergeSpinnerAdapter");
   }
 
@@ -83,7 +87,7 @@ public class MergeSpinnerAdapter extends MergeAdapter {
    * @param views
    *          List of views to add
    */
-  public void addViews(List<View> views) {
+  public int addViews(List<View> views) {
     throw new RuntimeException("Not supported with MergeSpinnerAdapter");
   }
 
@@ -96,7 +100,7 @@ public class MergeSpinnerAdapter extends MergeAdapter {
    * @param enabled
    *          false if views are disabled, true if enabled
    */
-  public void addViews(List<View> views, boolean enabled) {
+  public int addViews(List<View> views, boolean enabled, boolean visible) {
     throw new RuntimeException("Not supported with MergeSpinnerAdapter");
   }
 }


### PR DESCRIPTION
I needed the ability to change the visibility of all items after adding them. For example, I wanted to add a help message as header which could be "removed" later on. Setting the visibility of the View to "GONE" does not help as the ListView still reserves space for this item. 

For this reason I modified the MergeAdapter. After adding a "piece" (View, Views or Adapter), you get a pieceNo which uniquely identifies this piece. Later on you can toggle the visibility by using this pieceNo.

I updated the Demo to show the abilities of this code. Perhaps someone finds this code usefull!
