### PR TITLE
Remove backup to prevent manifest merger conflicts

### DIFF
--- a/merge/AndroidManifest.xml
+++ b/merge/AndroidManifest.xml
@@ -3,8 +3,4 @@
 	package="com.commonsware.cwac.merge"
 	android:versionCode="1"
 	android:versionName="1.0">
-
-	<application android:allowBackup="false">
-	</application>
-
 </manifest>


### PR DESCRIPTION
Not exactly sure if there was a reason for the "allowBackup" in the libraries manifest, but it seems to be the cause of a Gradle import issue. I don't know what version of Gradle this became an issue in, but it is present on my project using Gradle 0.11+ and Android Studio 0.6.1.

The error thrown is a manifest merge error. This change puts the manifest more in line with the [SackList manifest](https://github.com/commonsguy/cwac-sacklist/blob/master/sacklist/AndroidManifest.xml)

Currently, the solution to get around this is to set `useOldManifestMerger true` in your gradle build properties.

![screen shot 2014-06-14 at 7 33 39 pm](https://cloud.githubusercontent.com/assets/1014106/3279811/72e236ce-f41c-11e3-8850-e2307d585b25.png)
