### PR TITLE
manifest: fix regression with manifest merger

### DIFF
--- a/merge/AndroidManifest.xml
+++ b/merge/AndroidManifest.xml
@@ -3,4 +3,6 @@
 	package="com.commonsware.cwac.merge"
 	android:versionCode="1"
 	android:versionName="1.0">
+	
+	<application />
 </manifest>


### PR DESCRIPTION
Manifest merger requires `<application>` element, even if empty.
